### PR TITLE
Bug with fancy-button-allow-disable mixin 

### DIFF
--- a/lib/stylesheets/_fancy-buttons.sass
+++ b/lib/stylesheets/_fancy-buttons.sass
@@ -49,11 +49,11 @@ $fb-inset: true !default
   +background-clip(padding-box)
 
 =fancy-button-allow-disable($color: $fb-color, $font-size: $fb-font-size, $radius: $fb-radius, $border-width: $fb-border-width)
-  $fb-disable-allowed: $fb-allow-disable
-  $fb-allow-disable: true
+  $fb-disable-allowed: $fb-allow-disabled
+  $fb-allow-disabled: true
   +fancy-button-structure($font-size, $radius, $border-width)
   +fancy-button-colors-matte($color)
-  $fb-allow-disable: $fb-disable-allowed
+  $fb-allow-disabled: $fb-disable-allowed
 
 =fancy-button-matte($color: $fb-color, $font-size: $fb-font-size, $radius: $fb-radius, $border-width: $fb-border-width)
   +fancy-button-structure($font-size, $radius, $border-width)


### PR DESCRIPTION
When using the fancy-button-allow-disable mixin, an error is thrown because of a typo while accessing the default `$fb-allow-disabled` variable.
