### PR TITLE
Avoid disabled depress

### DIFF
--- a/lib/stylesheets/_fancy-buttons.sass
+++ b/lib/stylesheets/_fancy-buttons.sass
@@ -173,6 +173,8 @@ $fb-inset: true !default
   +fb-color($color, "default")
   +opacity($opacity)
   cursor: default !important
+  @if $fb-inset
+    +box-shadow(rgba(255,255,255, (lightness($color))/100), 0, 0, .1em, 1px, inset)
 
 .fancy-button-reset-base-class
   +fb-reset


### PR DESCRIPTION
This gives the user a more consistent feedback experience when dealing with a disabled button. It also has the side effect of preventing a mis-colored inset when trying to press a disabled button.

For example, if I have a colored button that I want to appear gray when disabled, I might do something like this:

```
button
  +fancy-button(blue)
  &.disabled, &[disabled]
    +disable-fancy-button(gray)
```

This pull-request ensures that both the disabled button is no longer "pressable" and prevents a surprising blue inset color on a pressed, but grey, disabled button.
