### PR TITLE
Fix for date format in gemspec

### DIFF
--- a/fancy-buttons.gemspec
+++ b/fancy-buttons.gemspec
@@ -4,7 +4,7 @@ require File.join(path, 'version')
 Gem::Specification.new do |gemspec|
   gemspec.name = "fancy-buttons"
   gemspec.version = FancyButtons::VERSION # Update the VERSION.yml file to set this.
-  gemspec.date = "#{Time.now.year}-#{Time.now.month}-#{Time.now.day}" # Automatically update for each build
+  gemspec.date = Time.now.strftime("%Y-%m-%d") # Automatically update for each build
   gemspec.description = "Fancy Buttons helps you easily style buttons with beautiful CSS3 features like gradients, rounded corners, etc. Don't worry the buttons also degrade nicely for browsers with no support. This requires the Compass stylesheet authoring framework."
   gemspec.homepage = "http://github.com/imathis/fancy-buttons"
   gemspec.authors = ["Brandon Mathis"]


### PR DESCRIPTION
Hi

This change fixes a problem with the date specification in the gemspec.

This line in the gemspec caused problems for me on August 1st:
`gemspec.date = "#{Time.now.year}-#{Time.now.month}-#{Time.now.day}"`

The resulting string would be "2011-8-1", which of course is an invalid date specification:

```
/Users/martin/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:990:in `date=': invalid date format in specification: "2011-8-1" (Gem::InvalidSpecificationException)
    from /Users/martin/.rvm/gems/ruby-1.9.2-p180@thalamus/bundler/gems/fancy-buttons-66ddfffa237a/fancy-buttons.gemspec:7:in `block in <main>'
…
```
