### PR TITLE
Adding readonly to the disabled styles…

### DIFF
--- a/lib/stylesheets/_fancy-buttons.sass
+++ b/lib/stylesheets/_fancy-buttons.sass
@@ -44,7 +44,7 @@ $fb-line-height: 1.2em !default
   +box-shadow(rgba(#fff, (lightness($color))/100) 0 0 .1em 1px inset)
   +background-clip(padding-box)
   @if $fb-allow-disabled
-    &.disabled, &[disabled]
+    &.disabled, &[disabled], &.readonly, &[readonly]
       +disable-fancy-button($color)
 
 =fancy-button-allow-disable($color: $fb-color, $font-size: $fb-font-size, $radius: $fb-radius, $border-width: $fb-border-width)
@@ -128,7 +128,7 @@ $fb-line-height: 1.2em !default
   &:active
     color: $active
   @if $fb-allow-disabled
-    &.disabled, &[disabled]
+    &.disabled, &[disabled], &.readonly, &[readonly]
       color: $color
 
 // Layout the button's box


### PR DESCRIPTION
Use case:
I have a form. When the user clicks on a (fancy) submit it gets a disabled attribute. Now the button's value doesn't get submitted and the server has no way of knowing which button the user clicked. More useful is setting the button to readonly, which avoids multiple form submissions but still sends its value.
