### PR TITLE
Fix support for Compass 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-src/.sass-cache/
+example/.sass-cache/
 example/stylesheets/
 example/sass/.sass-cache
 *.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,16 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    compass (0.10.6)
-      haml (>= 3.0.4)
-    gemcutter (0.6.1)
-    git (1.2.5)
-    haml (3.0.22)
-    jeweler (1.4.0)
-      gemcutter (>= 0.1.0)
-      git (>= 1.2.5)
-      rubyforge (>= 2.0.0)
-    json_pure (1.4.6)
-    rubyforge (2.0.4)
-      json_pure (>= 1.1.7)
+    chunky_png (1.2.5)
+    compass (0.12.0)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.1)
+    fssm (0.2.8.1)
+    sass (3.1.15)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   compass
-  jeweler

--- a/lib/stylesheets/_fancy-buttons.sass
+++ b/lib/stylesheets/_fancy-buttons.sass
@@ -1,4 +1,4 @@
-@import compass/css3/gradient
+@import compass/css3/images
 @import compass/css3/border-radius
 @import compass/css3/opacity
 @import compass/css3/text-shadow


### PR DESCRIPTION
Compass removed `compass/css3/gradient` and even though fancy-buttons no longer uses the deprecated syntax in that file, it was still being imported by fancy-buttons.

I bumped the Gemfile.lock file too, but only to ensure Compass 0.12 usage.

Aside, a Gemfile.lock file shouldn't be pushed to a gem's repository.  See http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
