### PR TITLE
Bug in fancy-button-custom mixin

### DIFF
--- a/lib/stylesheets/_fancy-buttons.sass
+++ b/lib/stylesheets/_fancy-buttons.sass
@@ -60,7 +60,7 @@ $fb-line-height: 1.2em !default
 
 =fancy-button-custom($color: $fb-color, $font-size: $fb-font-size, $radius: $fb-radius, $border-width: $fb-border-width)
   +fancy-button-structure($font-size, $radius, $border-width)
-  +fancy-button-colors-custom($color, $font-size, $radius, $border-width)
+  +fancy-button-colors-custom($color)
 
 =fancy-button-colors-matte($color: $fb-color, $hover: 0, $active: 0)
   $fb-current-style: $fb-gradient-style


### PR DESCRIPTION
fancy-button-colors-custom mixin call inside the fancy-button-custom definition has invalid arguments.
